### PR TITLE
Break in for loop

### DIFF
--- a/discovery.py
+++ b/discovery.py
@@ -44,6 +44,7 @@ class UdpListenThread(threading.Thread):
       for i in range(len(discovered)):
         if address == discovered[i]["address"]:
           del discovered[i]
+          break
       discovered.append(js)
       #print("\nDiscovered:\n{}".format(discovered))
 


### PR DESCRIPTION
Break in for loop to avoid going out of range.
If list with 2, delete first item and then try to read the second when it has shifted down to the first position.